### PR TITLE
Style: format with ruff format

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -6,38 +6,38 @@ import sys
 
 how = sys.argv[1]
 
-with open('pyproject.toml', encoding='utf-8') as f:
+with open("pyproject.toml", encoding="utf-8") as f:
     content = f.read()
 old_version = re.search(r'version = "(.*)"', content).group(1)
-version = old_version.split('.')
-if how == 'patch':
-    version = '.'.join(version[:-1] + [str(int(version[-1]) + 1)])
-elif how == 'minor':
-    version = '.'.join(version[:-2] + [str(int(version[-2]) + 1), '0'])
-elif how == 'major':
-    version = '.'.join([str(int(version[0]) + 1), '0', '0'])
+version = old_version.split(".")
+if how == "patch":
+    version = ".".join(version[:-1] + [str(int(version[-1]) + 1)])
+elif how == "minor":
+    version = ".".join(version[:-2] + [str(int(version[-2]) + 1), "0"])
+elif how == "major":
+    version = ".".join([str(int(version[0]) + 1), "0", "0"])
 content = content.replace(f'version = "{old_version}"', f'version = "{version}"')
-with open('pyproject.toml', 'w', encoding='utf-8') as f:
+with open("pyproject.toml", "w", encoding="utf-8") as f:
     f.write(content)
 
-with open('polars_upgrade/__init__.py', encoding='utf-8') as f:
+with open("polars_upgrade/__init__.py", encoding="utf-8") as f:
     content = f.read()
 content = content.replace(
     f'__version__ = "{old_version}"',
     f'__version__ = "{version}"',
 )
-with open('polars_upgrade/__init__.py', 'w', encoding='utf-8') as f:
+with open("polars_upgrade/__init__.py", "w", encoding="utf-8") as f:
     f.write(content)
 
-with open('README.md', encoding='utf-8') as f:
+with open("README.md", encoding="utf-8") as f:
     content = f.read()
 content = content.replace(
-    f'rev: {old_version}',
-    f'rev: {version}',
+    f"rev: {old_version}",
+    f"rev: {version}",
 )
-with open('README.md', 'w', encoding='utf-8') as f:
+with open("README.md", "w", encoding="utf-8") as f:
     f.write(content)
 
-subprocess.run(['git', 'commit', '-a', '-m', f'Bump version to {version}'])
-subprocess.run(['git', 'tag', '-a', version, '-m', version])
-subprocess.run(['git', 'push', '--follow-tags'])
+subprocess.run(["git", "commit", "-a", "-m", f"Bump version to {version}"])
+subprocess.run(["git", "tag", "-a", version, "-m", version])
+subprocess.run(["git", "push", "--follow-tags"])

--- a/polars_upgrade/__init__.py
+++ b/polars_upgrade/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 __version__ = "0.3.2"
 
 from polars_upgrade._main import fix_plugins as rewrite
 from polars_upgrade._main import Settings
 
-__all__ = ['rewrite', 'Settings']
+__all__ = ["rewrite", "Settings"]

--- a/polars_upgrade/__main__.py
+++ b/polars_upgrade/__main__.py
@@ -2,5 +2,5 @@ from __future__ import annotations
 
 from polars_upgrade._main import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/polars_upgrade/_ast_helpers.py
+++ b/polars_upgrade/_ast_helpers.py
@@ -10,7 +10,7 @@ from tokenize_rt import Offset
 def ast_parse(contents_text: str) -> ast.Module:
     # intentionally ignore warnings, we might be fixing warning-ridden syntax
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter("ignore")
         return ast.parse(contents_text.encode())
 
 
@@ -19,27 +19,26 @@ def ast_to_offset(node: ast.expr | ast.stmt) -> Offset:
 
 
 def is_name_attr(
-        node: ast.AST,
-        imports: dict[str, set[str]],
-        mods: tuple[str, ...],
-        names: Container[str],
+    node: ast.AST,
+    imports: dict[str, set[str]],
+    mods: tuple[str, ...],
+    names: Container[str],
 ) -> bool:
     return (
-        isinstance(node, ast.Name) and
-        node.id in names and
-        any(node.id in imports[mod] for mod in mods)
+        isinstance(node, ast.Name)
+        and node.id in names
+        and any(node.id in imports[mod] for mod in mods)
     ) or (
-        isinstance(node, ast.Attribute) and
-        isinstance(node.value, ast.Name) and
-        node.value.id in mods and
-        node.attr in names
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in mods
+        and node.attr in names
     )
 
 
 def has_starargs(call: ast.Call) -> bool:
-    return (
-        any(k.arg is None for k in call.keywords) or
-        any(isinstance(a, ast.Starred) for a in call.args)
+    return any(k.arg is None for k in call.keywords) or any(
+        isinstance(a, ast.Starred) for a in call.args
     )
 
 
@@ -52,17 +51,14 @@ def contains_await(node: ast.AST) -> bool:
 
 
 def is_async_listcomp(node: ast.ListComp) -> bool:
-    return (
-        any(gen.is_async for gen in node.generators) or
-        contains_await(node)
-    )
+    return any(gen.is_async for gen in node.generators) or contains_await(node)
 
 
 def is_type_check(node: ast.AST) -> bool:
     return (
-        isinstance(node, ast.Call) and
-        isinstance(node.func, ast.Name) and
-        node.func.id in {'isinstance', 'issubclass'} and
-        len(node.args) == 2 and
-        not has_starargs(node)
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"isinstance", "issubclass"}
+        and len(node.args) == 2
+        and not has_starargs(node)
     )

--- a/polars_upgrade/_data.py
+++ b/polars_upgrade/_data.py
@@ -27,13 +27,11 @@ class State(NamedTuple):
     in_annotation: bool = False
 
 
-AST_T = TypeVar('AST_T', bound=ast.AST)
+AST_T = TypeVar("AST_T", bound=ast.AST)
 TokenFunc = Callable[[int, list[Token]], None]
 ASTFunc = Callable[[State, AST_T, ast.AST], Iterable[tuple[Offset, TokenFunc]]]
 
-RECORD_FROM_IMPORTS = frozenset((
-    'polars',
-))
+RECORD_FROM_IMPORTS = frozenset(("polars",))
 
 FUNCS = collections.defaultdict(list)
 
@@ -42,6 +40,7 @@ def register(tp: type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
     def register_decorator(func: ASTFunc[AST_T]) -> ASTFunc[AST_T]:
         FUNCS[tp].append(func)
         return func
+
     return register_decorator
 
 
@@ -50,14 +49,14 @@ class ASTCallbackMapping(Protocol):
 
 
 def visit(
-        funcs: ASTCallbackMapping,
-        tree: ast.Module,
-        settings: Settings,
-        aliases: set[str] | None = None,
+    funcs: ASTCallbackMapping,
+    tree: ast.Module,
+    settings: Settings,
+    aliases: set[str] | None = None,
 ) -> dict[Offset, list[TokenFunc]]:
     if aliases is not None:
         _aliases = collections.defaultdict(set)
-        _aliases['polars'].update(aliases)
+        _aliases["polars"].update(aliases)
         initial_state = State(
             settings=settings,
             aliases=_aliases,
@@ -82,14 +81,14 @@ def visit(
 
         if isinstance(node, ast.Import):
             for import_ in node.names:
-                if import_.name == 'polars':
-                    state.aliases['polars'].add(import_.asname or import_.name)
-                elif import_.name == 'pandas':
-                    state.aliases['pandas'].add(import_.asname or import_.name)
+                if import_.name == "polars":
+                    state.aliases["polars"].add(import_.asname or import_.name)
+                elif import_.name == "pandas":
+                    state.aliases["pandas"].add(import_.asname or import_.name)
 
         for name in reversed(node._fields):
             value = getattr(node, name)
-            if name in {'annotation', 'returns'}:
+            if name in {"annotation", "returns"}:
                 next_state = state._replace(in_annotation=True)
             else:
                 next_state = state
@@ -105,9 +104,9 @@ def visit(
 
 def _import_plugins() -> None:
     plugins_path = _plugins.__path__
-    mod_infos = pkgutil.walk_packages(plugins_path, f'{_plugins.__name__}.')
+    mod_infos = pkgutil.walk_packages(plugins_path, f"{_plugins.__name__}.")
     for _, name, _ in mod_infos:
-        __import__(name, fromlist=['_trash'])
+        __import__(name, fromlist=["_trash"])
 
 
 _import_plugins()

--- a/polars_upgrade/_plugins/enable_string_cache.py
+++ b/polars_upgrade/_plugins/enable_string_cache.py
@@ -19,42 +19,39 @@ def rewrite_to_enable(
     i: int,
     tokens: list[Token],
 ) -> None:
-    j = find_op(tokens, i, '(')
+    j = find_op(tokens, i, "(")
     func_args, _ = parse_call_args(tokens, j)
     i = func_args[0][0]
-    tokens[i] = tokens[i]._replace(src='')
+    tokens[i] = tokens[i]._replace(src="")
 
 
 def rewrite_to_disable(
     i: int,
     tokens: list[Token],
 ) -> None:
-    j = find_op(tokens, i, '(')
+    j = find_op(tokens, i, "(")
     func_args, _ = parse_call_args(tokens, j)
-    while not (
-        tokens[i].name == 'NAME' and
-        tokens[i].src == 'enable_string_cache'
-    ):
+    while not (tokens[i].name == "NAME" and tokens[i].src == "enable_string_cache"):
         i += 1
-    tokens[i] = tokens[i]._replace(src='disable_string_cache')
+    tokens[i] = tokens[i]._replace(src="disable_string_cache")
     i = func_args[0][0]
-    tokens[i] = tokens[i]._replace(src='')
+    tokens[i] = tokens[i]._replace(src="")
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            state.settings.target_version >= (0, 19, 3) and
-            isinstance(node.func, ast.Attribute) and
-            isinstance(node.func.value, ast.Name) and
-            node.func.attr == 'enable_string_cache' and
-            node.func.value.id in state.aliases['polars'] and
-            len(node.args) == 1 and
-            isinstance(node.args[0], ast.Constant)
+        state.settings.target_version >= (0, 19, 3)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.attr == "enable_string_cache"
+        and node.func.value.id in state.aliases["polars"]
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Constant)
     ):
         if node.args[0].value is True:
             func = functools.partial(

--- a/polars_upgrade/_plugins/group_by_dynamic_truncate.py
+++ b/polars_upgrade/_plugins/group_by_dynamic_truncate.py
@@ -23,7 +23,7 @@ def _use_label(
     truncate_value: object,
     truncate_idx: int,
 ) -> None:
-    j = find_op(tokens, i, '(')
+    j = find_op(tokens, i, "(")
     func_args, _ = parse_call_args(tokens, j)
     if truncate_value is True:
         new = 'label="left"'
@@ -41,22 +41,21 @@ def _use_label(
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr == 'group_by_dynamic' and
-            len(node.keywords) >= 1 and
-            state.settings.target_version >= (0, 19, 4)
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "group_by_dynamic"
+        and len(node.keywords) >= 1
+        and state.settings.target_version >= (0, 19, 4)
     ):
         truncate_idx = None
         truncate_value = None
         for n, keyword_argument in enumerate(node.keywords):
-            if (
-                keyword_argument.arg == 'truncate' and
-                isinstance(keyword_argument.value, ast.Constant)
+            if keyword_argument.arg == "truncate" and isinstance(
+                keyword_argument.value, ast.Constant
             ):
                 truncate_idx = n
                 truncate_value = keyword_argument.value.value

--- a/polars_upgrade/_plugins/map_dict.py
+++ b/polars_upgrade/_plugins/map_dict.py
@@ -25,7 +25,7 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
@@ -37,47 +37,49 @@ def rename_and_add_default(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
-    start_paren = find_op(tokens, i, '(')
-    close_paren = find_op(tokens, start_paren, ')')
+    start_paren = find_op(tokens, i, "(")
+    close_paren = find_op(tokens, start_paren, ")")
     # is there a comma before the close paren?
     i = close_paren - 1
     while tokens[i].name in NON_CODING_TOKENS:
         i -= 1
-    if ',' not in tokens[i].src:
-        tokens.insert(i + 1, Token('OP', ', '))
-        tokens.insert(i + 2, Token('NAME', 'default'))
-        tokens.insert(i + 3, Token('OP', '='))
-        tokens.insert(i + 4, Token('NUMBER', 'None'))
+    if "," not in tokens[i].src:
+        tokens.insert(i + 1, Token("OP", ", "))
+        tokens.insert(i + 2, Token("NAME", "default"))
+        tokens.insert(i + 3, Token("OP", "="))
+        tokens.insert(i + 4, Token("NUMBER", "None"))
     else:
-        tokens.insert(i + 1, Token('NAME', 'default'))
-        tokens.insert(i + 2, Token('OP', '='))
-        tokens.insert(i + 3, Token('NUMBER', 'None'))
+        tokens.insert(i + 1, Token("NAME", "default"))
+        tokens.insert(i + 2, Token("OP", "="))
+        tokens.insert(i + 3, Token("NUMBER", "None"))
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            is_simple_expression(node.func.value, state.aliases['polars']) and
-            node.func.attr == 'map_dict' and
-            state.settings.target_version >= (0, 19, 16)
+        isinstance(node.func, ast.Attribute)
+        and is_simple_expression(node.func.value, state.aliases["polars"])
+        and node.func.attr == "map_dict"
+        and state.settings.target_version >= (0, 19, 16)
     ):
-        if any(k.arg == 'default' for k in node.keywords):
+        if any(k.arg == "default" for k in node.keywords):
             func = functools.partial(
-                rename, name=node.func.attr,
-                new='replace',
+                rename,
+                name=node.func.attr,
+                new="replace",
             )
             yield ast_to_offset(node), func
         else:
             func = functools.partial(
-                rename_and_add_default, name=node.func.attr,
-                new='replace',
+                rename_and_add_default,
+                name=node.func.attr,
+                new="replace",
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/map_groups.py
+++ b/polars_upgrade/_plugins/map_groups.py
@@ -20,26 +20,28 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            node.attr == 'apply' and
-            isinstance(node.value, ast.Call) and
-            isinstance(node.value.func, ast.Attribute) and
-            node.value.func.attr in (
-                'group_by', 'group_by_dynamic',
-                'rolling',
-            ) and
-            state.settings.target_version >= (0, 19, 0)
+        node.attr == "apply"
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr
+        in (
+            "group_by",
+            "group_by_dynamic",
+            "rolling",
+        )
+        and state.settings.target_version >= (0, 19, 0)
     ):
-        func = functools.partial(rename, name=node.attr, new='map_groups')
+        func = functools.partial(rename, name=node.attr, new="map_groups")
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_dataframe_calls.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_calls.py
@@ -20,34 +20,34 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
-    while not (tokens[i].name == 'OP' and tokens[i].src == '('):
+    while not (tokens[i].name == "OP" and tokens[i].src == "("):
         i += 1
-    tokens[i] = tokens[i]._replace(src='')
-    while not (tokens[i].name == 'OP' and tokens[i].src == ')'):
+    tokens[i] = tokens[i]._replace(src="")
+    while not (tokens[i].name == "OP" and tokens[i].src == ")"):
         i += 1
-    tokens[i] = tokens[i]._replace(src='')
+    tokens[i] = tokens[i]._replace(src="")
 
 
 RENAMINGS = {
-    'approx_n_unique': ((0, 20, 11), 'select(pl.all().approx_n_unique())'),
+    "approx_n_unique": ((0, 20, 11), "select(pl.all().approx_n_unique())"),
 }
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr in RENAMINGS and
-            'pl' in state.aliases['polars'] and
-            not node.args and
-            not node.keywords
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in RENAMINGS
+        and "pl" in state.aliases["polars"]
+        and not node.args
+        and not node.keywords
     ):
         min_version, new_name = RENAMINGS[node.func.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_dataframe_method_arguments.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_method_arguments.py
@@ -35,20 +35,20 @@ def rename(
 
 # function name -> (min_version, old, new)
 RENAMINGS = {
-    'write_database': ((0, 20, 0), 'if_exists', 'if_table_exists'),
+    "write_database": ((0, 20, 0), "if_exists", "if_table_exists"),
 }
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr in RENAMINGS and
-            len(node.keywords) >= 1
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in RENAMINGS
+        and len(node.keywords) >= 1
     ):
         min_version, old, new = RENAMINGS[node.func.attr]
         if not state.settings.target_version >= min_version:
@@ -59,7 +59,10 @@ def visit_Call(
         else:
             return
         func = functools.partial(
-            rename, line=keyword.lineno,
-            utf8_byte_offset=keyword.col_offset, old=old, new=new,
+            rename,
+            line=keyword.lineno,
+            utf8_byte_offset=keyword.col_offset,
+            old=old,
+            new=new,
         )
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_dataframe_method_values.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_method_values.py
@@ -35,20 +35,17 @@ def rename(
 
 # function name -> (min_version, argument, old, new)
 RENAMINGS = {
-    'pivot': ((0, 20, 5), 'aggregate_function', 'count', 'len'),
+    "pivot": ((0, 20, 5), "aggregate_function", "count", "len"),
 }
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if (
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr in RENAMINGS
-    ):
+    if isinstance(node.func, ast.Attribute) and node.func.attr in RENAMINGS:
         min_version, argument, old, new = RENAMINGS[node.func.attr]
         if argument not in {kw.arg for kw in node.keywords}:
             return
@@ -58,13 +55,16 @@ def visit_Call(
             if keyword.arg == argument:
                 break
         else:
-            raise AssertionError('unreachable code, please report bug')
+            raise AssertionError("unreachable code, please report bug")
         if not isinstance(keyword.value, ast.Constant):
             return
         if keyword.value.value != old:
             return
         func = functools.partial(
-            rename, line=keyword.lineno,
-            utf8_byte_offset=keyword.value.col_offset, old=old, new=new,
+            rename,
+            line=keyword.lineno,
+            utf8_byte_offset=keyword.value.col_offset,
+            old=old,
+            new=new,
         )
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_dataframe_methods.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_methods.py
@@ -20,26 +20,24 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 RENAMINGS = {
-    'groupby_dynamic': ((0, 19, 0), 'group_by_dynamic'),
-    'groupby_rolling': ((0, 19, 0), 'rolling'),
+    "groupby_dynamic": ((0, 19, 0), "group_by_dynamic"),
+    "groupby_rolling": ((0, 19, 0), "rolling"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if (
-            node.attr in RENAMINGS
-    ):
+    if node.attr in RENAMINGS:
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:
             func = functools.partial(rename, name=node.attr, new=new_name)

--- a/polars_upgrade/_plugins/renamed_datetime_functions.py
+++ b/polars_upgrade/_plugins/renamed_datetime_functions.py
@@ -21,30 +21,38 @@ def rename(
     name: str,
     new_name: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new_name)
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            state.settings.target_version >= (0, 19, 13) and
-            isinstance(node.value, ast.Attribute) and
-            is_simple_expression(node.value.value, state.aliases['polars']) and
-            node.value.attr == 'dt' and
-            node.attr in (
-                'nanoseconds', 'microseconds', 'milliseconds',
-                'seconds', 'minutes', 'hours', 'days', 'weeks',
-            )
+        state.settings.target_version >= (0, 19, 13)
+        and isinstance(node.value, ast.Attribute)
+        and is_simple_expression(node.value.value, state.aliases["polars"])
+        and node.value.attr == "dt"
+        and node.attr
+        in (
+            "nanoseconds",
+            "microseconds",
+            "milliseconds",
+            "seconds",
+            "minutes",
+            "hours",
+            "days",
+            "weeks",
+        )
     ):
-        new_attr = f'total_{node.attr}'
+        new_attr = f"total_{node.attr}"
         func = functools.partial(
-            rename, name=node.attr,
+            rename,
+            name=node.attr,
             new_name=new_attr,
         )
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_expr_arguments.py
+++ b/polars_upgrade/_plugins/renamed_expr_arguments.py
@@ -36,30 +36,30 @@ def rename(
 
 # function name -> (min_version, old, new)
 RENAMINGS = {
-    'shift': ((0, 19, 11), 'periods', 'n'),
-    'any': ((0, 19, 0), 'drop_nulls', 'ignore_nulls'),
-    'all': ((0, 19, 0), 'drop_nulls', 'ignore_nulls'),
-    'value_counts': ((0, 19, 0), 'multithreaded', 'parallel'),
-    'shift_and_fill': ((0, 19, 11), 'periods', 'n'),
-    'map_dict': ((0, 19, 16), 'remapping', 'mapping'),
+    "shift": ((0, 19, 11), "periods", "n"),
+    "any": ((0, 19, 0), "drop_nulls", "ignore_nulls"),
+    "all": ((0, 19, 0), "drop_nulls", "ignore_nulls"),
+    "value_counts": ((0, 19, 0), "multithreaded", "parallel"),
+    "shift_and_fill": ((0, 19, 11), "periods", "n"),
+    "map_dict": ((0, 19, 16), "remapping", "mapping"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            is_simple_expression(node.value, state.aliases['polars']) and
-            isinstance(parent, ast.Call) and
-            isinstance(parent.func, ast.Attribute) and
-            parent.func.attr in RENAMINGS and
-            not (
-                isinstance(node.value, ast.Attribute) and
-                node.value.attr in ('list', 'name', 'str', 'struct', 'dt')
-            )
+        is_simple_expression(node.value, state.aliases["polars"])
+        and isinstance(parent, ast.Call)
+        and isinstance(parent.func, ast.Attribute)
+        and parent.func.attr in RENAMINGS
+        and not (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr in ("list", "name", "str", "struct", "dt")
+        )
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]
         for keyword in parent.keywords:
@@ -69,7 +69,10 @@ def visit_Attribute(
             return
         if state.settings.target_version >= min_version:
             func = functools.partial(
-                rename, line=keyword.lineno,
-                utf8_byte_offset=keyword.col_offset, old=old, new=new,
+                rename,
+                line=keyword.lineno,
+                utf8_byte_offset=keyword.col_offset,
+                old=old,
+                new=new,
             )
             yield ast_to_offset(parent), func

--- a/polars_upgrade/_plugins/renamed_expr_functions.py
+++ b/polars_upgrade/_plugins/renamed_expr_functions.py
@@ -21,46 +21,46 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 RENAMINGS = {
-    'cumcount': ((0, 19, 14), 'cum_count'),
-    'cummax': ((0, 19, 14), 'cum_max'),
-    'cummin': ((0, 19, 14), 'cum_min'),
-    'cumprod': ((0, 19, 14), 'cum_prod'),
-    'cumsum': ((0, 19, 14), 'cum_sum'),
-    'take': ((0, 19, 14), 'gather'),
-    'take_every': ((0, 19, 14), 'gather_every'),
-    'is_last': ((0, 19, 3), 'is_last_distinct'),
-    'is_first': ((0, 19, 3), 'is_first_distinct'),
-    'rolling_apply': ((0, 19, 0), 'rolling_map'),
-    'apply': ((0, 19, 0), 'map_elements'),
-    'map': ((0, 19, 0), 'map_batches'),
-    'is_not': ((0, 19, 2), 'not_'),
-    'keep_name': ((0, 19, 12), 'name.keep'),
-    'suffix': ((0, 19, 12), 'name.suffix'),
-    'prefix': ((0, 19, 12), 'name.prefix'),
-    'map_alias': ((0, 19, 12), 'name.map'),
-    'where': ((0, 20, 4), 'filter'),
+    "cumcount": ((0, 19, 14), "cum_count"),
+    "cummax": ((0, 19, 14), "cum_max"),
+    "cummin": ((0, 19, 14), "cum_min"),
+    "cumprod": ((0, 19, 14), "cum_prod"),
+    "cumsum": ((0, 19, 14), "cum_sum"),
+    "take": ((0, 19, 14), "gather"),
+    "take_every": ((0, 19, 14), "gather_every"),
+    "is_last": ((0, 19, 3), "is_last_distinct"),
+    "is_first": ((0, 19, 3), "is_first_distinct"),
+    "rolling_apply": ((0, 19, 0), "rolling_map"),
+    "apply": ((0, 19, 0), "map_elements"),
+    "map": ((0, 19, 0), "map_batches"),
+    "is_not": ((0, 19, 2), "not_"),
+    "keep_name": ((0, 19, 12), "name.keep"),
+    "suffix": ((0, 19, 12), "name.suffix"),
+    "prefix": ((0, 19, 12), "name.prefix"),
+    "map_alias": ((0, 19, 12), "name.map"),
+    "where": ((0, 20, 4), "filter"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            is_simple_expression(node.value, state.aliases['polars']) and
-            node.attr in RENAMINGS and
-            not (
-                isinstance(node.value, ast.Attribute) and
-                node.value.attr in ('list', 'name', 'str', 'struct', 'dt')
-            )
+        is_simple_expression(node.value, state.aliases["polars"])
+        and node.attr in RENAMINGS
+        and not (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr in ("list", "name", "str", "struct", "dt")
+        )
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_list_arguments.py
+++ b/polars_upgrade/_plugins/renamed_list_arguments.py
@@ -36,26 +36,23 @@ def rename(
 
 # function name -> (min_version, old, new)
 RENAMINGS = {
-    'shift': ((0, 19, 11), 'periods', 'n'),
-    'take': ((0, 19, 14), 'index', 'indices'),
+    "shift": ((0, 19, 11), "periods", "n"),
+    "take": ((0, 19, 14), "index", "indices"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            is_simple_expression(node.value, state.aliases['polars']) and
-            isinstance(parent, ast.Call) and
-            isinstance(parent.func, ast.Attribute) and
-            parent.func.attr in RENAMINGS and
-            (
-                isinstance(node.value, ast.Attribute) and
-                node.value.attr == 'list'
-            )
+        is_simple_expression(node.value, state.aliases["polars"])
+        and isinstance(parent, ast.Call)
+        and isinstance(parent.func, ast.Attribute)
+        and parent.func.attr in RENAMINGS
+        and (isinstance(node.value, ast.Attribute) and node.value.attr == "list")
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]
         for keyword in parent.keywords:
@@ -65,7 +62,10 @@ def visit_Attribute(
             return
         if state.settings.target_version >= min_version:
             func = functools.partial(
-                rename, line=keyword.lineno,
-                utf8_byte_offset=keyword.col_offset, old=old, new=new,
+                rename,
+                line=keyword.lineno,
+                utf8_byte_offset=keyword.col_offset,
+                old=old,
+                new=new,
             )
             yield ast_to_offset(parent), func

--- a/polars_upgrade/_plugins/renamed_list_functions.py
+++ b/polars_upgrade/_plugins/renamed_list_functions.py
@@ -21,35 +21,36 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 RENAMINGS = {
-    'count_match': ((0, 19, 3), 'count_matches'),
-    'lengths': ((0, 19, 8), 'len'),
-    'take': ((0, 19, 14), 'gather'),
+    "count_match": ((0, 19, 3), "count_matches"),
+    "lengths": ((0, 19, 8), "len"),
+    "take": ((0, 19, 14), "gather"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.value, ast.Attribute) and
-            is_simple_expression(node.value.value, state.aliases['polars']) and
-            node.value.attr == 'list' and
-            node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute)
+        and is_simple_expression(node.value.value, state.aliases["polars"])
+        and node.value.attr == "list"
+        and node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:
             new_attr = new_name
             func = functools.partial(
-                rename, name=node.attr,
+                rename,
+                name=node.attr,
                 new=new_attr,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_meta_functions.py
+++ b/polars_upgrade/_plugins/renamed_meta_functions.py
@@ -21,33 +21,34 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 RENAMINGS = {
-    'write_json': ((0, 20, 11), 'serialize'),
+    "write_json": ((0, 20, 11), "serialize"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.value, ast.Attribute) and
-            is_simple_expression(node.value.value, state.aliases['polars']) and
-            node.value.attr == 'meta' and
-            node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute)
+        and is_simple_expression(node.value.value, state.aliases["polars"])
+        and node.value.attr == "meta"
+        and node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:
             new_attr = new_name
             func = functools.partial(
-                rename, name=node.attr,
+                rename,
+                name=node.attr,
                 new=new_attr,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_str_arguments.py
+++ b/polars_upgrade/_plugins/renamed_str_arguments.py
@@ -36,28 +36,25 @@ def rename(
 
 # function name -> (min_version, old, new)
 RENAMINGS = {
-    'zfill': ((0, 19, 12), 'alignment', 'length'),
-    'parse_int': ((0, 19, 14), 'radix', 'base'),
-    'ljust': ((0, 19, 12), 'width', 'length'),
-    'rjust': ((0, 19, 12), 'width', 'length'),
+    "zfill": ((0, 19, 12), "alignment", "length"),
+    "parse_int": ((0, 19, 14), "radix", "base"),
+    "ljust": ((0, 19, 12), "width", "length"),
+    "rjust": ((0, 19, 12), "width", "length"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            is_simple_expression(node.value, state.aliases['polars']) and
-            isinstance(parent, ast.Call) and
-            isinstance(parent.func, ast.Attribute) and
-            parent.func.attr in RENAMINGS and
-            (
-                isinstance(node.value, ast.Attribute) and
-                node.value.attr == 'str'
-            )
+        is_simple_expression(node.value, state.aliases["polars"])
+        and isinstance(parent, ast.Call)
+        and isinstance(parent.func, ast.Attribute)
+        and parent.func.attr in RENAMINGS
+        and (isinstance(node.value, ast.Attribute) and node.value.attr == "str")
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]
         for keyword in parent.keywords:
@@ -67,7 +64,10 @@ def visit_Attribute(
             return
         if state.settings.target_version >= min_version:
             func = functools.partial(
-                rename, line=keyword.lineno,
-                utf8_byte_offset=keyword.col_offset, old=old, new=new,
+                rename,
+                line=keyword.lineno,
+                utf8_byte_offset=keyword.col_offset,
+                old=old,
+                new=new,
             )
             yield ast_to_offset(parent), func

--- a/polars_upgrade/_plugins/renamed_string_functions.py
+++ b/polars_upgrade/_plugins/renamed_string_functions.py
@@ -21,41 +21,42 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
 
 RENAMINGS = {
-    'strip': ((0, 19, 3), 'strip_chars'),
-    'lstrip': ((0, 19, 3), 'strip_chars_start'),
-    'rstrip': ((0, 19, 3), 'strip_chars_end'),
-    'count_match': ((0, 19, 3), 'count_matches'),
-    'lengths': ((0, 19, 8), 'len_bytes'),
-    'n_chars': ((0, 19, 8), 'len_chars'),
-    'ljust': ((0, 19, 12), 'pad_end'),
-    'rjust': ((0, 19, 12), 'pad_start'),
-    'json_extract': ((0, 19, 15), 'json_decode'),
+    "strip": ((0, 19, 3), "strip_chars"),
+    "lstrip": ((0, 19, 3), "strip_chars_start"),
+    "rstrip": ((0, 19, 3), "strip_chars_end"),
+    "count_match": ((0, 19, 3), "count_matches"),
+    "lengths": ((0, 19, 8), "len_bytes"),
+    "n_chars": ((0, 19, 8), "len_chars"),
+    "ljust": ((0, 19, 12), "pad_end"),
+    "rjust": ((0, 19, 12), "pad_start"),
+    "json_extract": ((0, 19, 15), "json_decode"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.value, ast.Attribute) and
-            is_simple_expression(node.value.value, state.aliases['polars']) and
-            node.value.attr == 'str' and
-            node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute)
+        and is_simple_expression(node.value.value, state.aliases["polars"])
+        and node.value.attr == "str"
+        and node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:
             new_attr = new_name
             func = functools.partial(
-                rename, name=node.attr,
+                rename,
+                name=node.attr,
                 new=new_attr,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_toplevel_arguments.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_arguments.py
@@ -35,64 +35,64 @@ def rename(
 
 # function name -> (min_version, old, new)
 RENAMINGS = {
-    'scan_ndjson': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "scan_ndjson": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_csv': [
-        ((0, 19, 14), 'comment_char', 'comment_prefix'),
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "read_csv": [
+        ((0, 19, 14), "comment_char", "comment_prefix"),
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_csv_batched': [
-        ((0, 19, 14), 'comment_char', 'comment_prefix'),
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "read_csv_batched": [
+        ((0, 19, 14), "comment_char", "comment_prefix"),
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'scan_csv': [
-        ((0, 19, 14), 'comment_char', 'comment_prefix'),
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "scan_csv": [
+        ((0, 19, 14), "comment_char", "comment_prefix"),
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_ipc': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "read_ipc": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_ipc_stream': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "read_ipc_stream": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'scan_ipc': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "scan_ipc": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_parquet': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "read_parquet": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'scan_parquet': [
-        ((0, 20, 4), 'row_count_name', 'row_index_name'),
-        ((0, 20, 4), 'row_count_offset', 'row_index_offset'),
+    "scan_parquet": [
+        ((0, 20, 4), "row_count_name", "row_index_name"),
+        ((0, 20, 4), "row_count_offset", "row_index_offset"),
     ],
-    'read_excel': [
-        ((0, 20, 6), 'xlsx2csv_options', 'engine_options'),
-        ((0, 20, 7), 'read_csv_options', 'read_options'),
+    "read_excel": [
+        ((0, 20, 6), "xlsx2csv_options", "engine_options"),
+        ((0, 20, 7), "read_csv_options", "read_options"),
     ],
 }
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            node.func.attr in RENAMINGS and
-            isinstance(node.func.value, ast.Name) and
-            node.func.value.id in state.aliases['polars'] and
-            len(node.keywords) >= 1
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in RENAMINGS
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in state.aliases["polars"]
+        and len(node.keywords) >= 1
     ):
         for min_version, old, new in RENAMINGS[node.func.attr]:
             if not state.settings.target_version >= min_version:
@@ -103,7 +103,10 @@ def visit_Call(
             else:
                 continue
             func = functools.partial(
-                rename, line=keyword.lineno,
-                utf8_byte_offset=keyword.col_offset, old=old, new=new,
+                rename,
+                line=keyword.lineno,
+                utf8_byte_offset=keyword.col_offset,
+                old=old,
+                new=new,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_toplevel_functions.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_functions.py
@@ -13,33 +13,34 @@ from polars_upgrade._data import TokenFunc
 from polars_upgrade._token_helpers import replace_name
 
 RENAMINGS = {
-    'avg': ((0, 18, 12), 'mean'),
-    'map': ((0, 19, 0), 'map_batches'),
-    'apply': ((0, 19, 0), 'map_groups'),
-    'cumsum': ((0, 19, 14), 'cum_sum'),
-    'cumfold': ((0, 19, 14), 'cum_fold'),
-    'cumreduce': ((0, 19, 14), 'cum_reduce'),
-    'cumsum_horizontal': ((0, 19, 14), 'cum_sum_horizontal'),
-    'threadpool_size': ((0, 20, 7), 'thread_pool_size'),
+    "avg": ((0, 18, 12), "mean"),
+    "map": ((0, 19, 0), "map_batches"),
+    "apply": ((0, 19, 0), "map_groups"),
+    "cumsum": ((0, 19, 14), "cum_sum"),
+    "cumfold": ((0, 19, 14), "cum_fold"),
+    "cumreduce": ((0, 19, 14), "cum_reduce"),
+    "cumsum_horizontal": ((0, 19, 14), "cum_sum_horizontal"),
+    "threadpool_size": ((0, 20, 7), "thread_pool_size"),
 }
 
 
 @register(ast.Attribute)
 def visit_Attribute(
-        state: State,
-        node: ast.Attribute,
-        parent: ast.AST,
+    state: State,
+    node: ast.Attribute,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.value, ast.Name) and
-            node.value.id in state.aliases['polars'] and
-            node.attr in RENAMINGS
+        isinstance(node.value, ast.Name)
+        and node.value.id in state.aliases["polars"]
+        and node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:
-            new_attr = f'{node.value.id}.{new_name}'
+            new_attr = f"{node.value.id}.{new_name}"
             func = functools.partial(
-                replace_name, name=node.attr,
+                replace_name,
+                name=node.attr,
                 new=new_attr,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/renamed_toplevel_no_arg_functions.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_no_arg_functions.py
@@ -13,29 +13,30 @@ from polars_upgrade._data import TokenFunc
 from polars_upgrade._token_helpers import replace_name
 
 RENAMINGS = {
-    'count': ((0, 20, 4), 'len'),
+    "count": ((0, 20, 4), "len"),
 }
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.func, ast.Attribute) and
-            isinstance(node.func.value, ast.Name) and
-            node.func.value.id in state.aliases['polars'] and
-            node.func.attr in RENAMINGS and
-            not node.args and
-            not node.keywords
+        isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in state.aliases["polars"]
+        and node.func.attr in RENAMINGS
+        and not node.args
+        and not node.keywords
     ):
         min_version, new_name = RENAMINGS[node.func.attr]
         if state.settings.target_version >= min_version:
-            new_attr = f'{node.func.value.id}.{new_name}'
+            new_attr = f"{node.func.value.id}.{new_name}"
             func = functools.partial(
-                replace_name, name=node.func.attr,
+                replace_name,
+                name=node.func.attr,
                 new=new_attr,
             )
             yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/saturating.py
+++ b/polars_upgrade/_plugins/saturating.py
@@ -17,19 +17,20 @@ def myfunc(
     i: int,
     tokens: list[Token],
 ) -> None:
-    tokens[i] = tokens[i]._replace(src=tokens[i].src.replace('mo_saturating', 'mo'))
+    tokens[i] = tokens[i]._replace(src=tokens[i].src.replace("mo_saturating", "mo"))
 
 
 @register(ast.Constant)
 def visit_Constant(
-        state: State,
-        node: ast.Constant,
-        parent: ast.AST,
+    state: State,
+    node: ast.Constant,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-            isinstance(node.value, str) and node.value.endswith('mo_saturating') and
-            isinstance(parent, (ast.Call, ast.keyword)) and
-            state.settings.target_version >= (0, 19, 3)
+        isinstance(node.value, str)
+        and node.value.endswith("mo_saturating")
+        and isinstance(parent, (ast.Call, ast.keyword))
+        and state.settings.target_version >= (0, 19, 3)
     ):
         func = functools.partial(myfunc)
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/with_row_count.py
+++ b/polars_upgrade/_plugins/with_row_count.py
@@ -20,7 +20,7 @@ def rename(
     name: str,
     new: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
 
@@ -33,45 +33,42 @@ def rename_and_add_argument(
     new: str,
     argument: str,
 ) -> None:
-    while not (tokens[i].name == 'NAME' and tokens[i].src == name):
+    while not (tokens[i].name == "NAME" and tokens[i].src == name):
         i += 1
     tokens[i] = tokens[i]._replace(src=new)
-    while not (tokens[i].name == 'OP' and tokens[i].src == '('):
+    while not (tokens[i].name == "OP" and tokens[i].src == "("):
         i += 1
-    tokens[i] = tokens[i]._replace(src=f'({argument}, ')
+    tokens[i] = tokens[i]._replace(src=f"({argument}, ")
 
 
 @register(ast.Call)
 def visit_Call(
-        state: State,
-        node: ast.Call,
-        parent: ast.AST,
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     # If `name` was specified we can just rename, easy
     if (
-        isinstance(node.func, ast.Attribute) and
-        node.func.attr == 'with_row_count' and
-        (
-            node.args or
-            'name' in {kw.arg for kw in node.keywords}
-        ) and
-        state.settings.target_version >= (0, 20, 4)
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "with_row_count"
+        and (node.args or "name" in {kw.arg for kw in node.keywords})
+        and state.settings.target_version >= (0, 20, 4)
     ):
-        func = functools.partial(rename, name=node.func.attr, new='with_row_index')
+        func = functools.partial(rename, name=node.func.attr, new="with_row_index")
         yield ast_to_offset(node), func
 
     # If no `name` was specified, we set it to 'row_nr' to not break code
     if (
-        isinstance(node.func, ast.Attribute) and
-        node.func.attr == 'with_row_count' and
-        not node.args and
-        'name' not in {kw.arg for kw in node.keywords} and
-        state.settings.target_version >= (0, 20, 4)
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "with_row_count"
+        and not node.args
+        and "name" not in {kw.arg for kw in node.keywords}
+        and state.settings.target_version >= (0, 20, 4)
     ):
         func = functools.partial(
             rename_and_add_argument,
             name=node.func.attr,
-            new='with_row_index',
+            new="with_row_index",
             argument='"row_nr"',
         )
         yield ast_to_offset(node), func

--- a/polars_upgrade/_string_helpers.py
+++ b/polars_upgrade/_string_helpers.py
@@ -5,7 +5,7 @@ import re
 import string
 from typing import Optional
 
-NAMED_UNICODE_RE = re.compile(r'(?<!\\)(?:\\\\)*(\\N\{[^}]+\})')
+NAMED_UNICODE_RE = re.compile(r"(?<!\\)(?:\\\\)*(\\N\{[^}]+\})")
 
 DotFormatPart = tuple[str, Optional[str], Optional[str], Optional[str]]
 
@@ -42,21 +42,21 @@ def unparse_parsed_string(parsed: list[DotFormatPart]) -> str:
         ret, field_name, format_spec, conversion = tup
         ret = curly_escape(ret)
         if field_name is not None:
-            ret += '{' + field_name
+            ret += "{" + field_name
             if conversion:
-                ret += '!' + conversion
+                ret += "!" + conversion
             if format_spec:
-                ret += ':' + format_spec
-            ret += '}'
+                ret += ":" + format_spec
+            ret += "}"
         return ret
 
-    return ''.join(_convert_tup(tup) for tup in parsed)
+    return "".join(_convert_tup(tup) for tup in parsed)
 
 
 def curly_escape(s: str) -> str:
     parts = NAMED_UNICODE_RE.split(s)
-    return ''.join(
-        part.replace('{', '{{').replace('}', '}}')
+    return "".join(
+        part.replace("{", "{{").replace("}", "}}")
         if not NAMED_UNICODE_RE.fullmatch(part)
         else part
         for part in parts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,29 +47,29 @@ select = [
   "ALL",
 ]
 ignore = [
-  'A003',
-  'ANN101',
-  'ANN401',
-  'ARG002',  # todo: enable
-  'ARG003',  # todo: enable
-  'C901',
-  'D',
-  'DTZ',
-  'E501',
-  'FBT003',  # todo: enable
-  'FIX',
-  'PD',
-  'PLR0911',
-  'PLR0912',
-  'PLR5501',
-  'PLR2004',
-  'PT011',
-  'PTH',
-  'RET505',
-  'S',
-  'SLF001',
-  'TD',
-  'TRY004'
+  "A003",
+  "ANN101",
+  "ANN401",
+  "ARG002",  # todo: enable
+  "ARG003",  # todo: enable
+  "C901",
+  "D",
+  "DTZ",
+  "E501",
+  "FBT003",  # todo: enable
+  "FIX",
+  "PD",
+  "PLR0911",
+  "PLR0912",
+  "PLR2004",
+  "PLR5501",
+  "PT011",
+  "PTH",
+  "RET505",
+  "S",
+  "SLF001",
+  "TD",
+  "TRY004"
 ]
 
 [tool.ruff.lint.isort]
@@ -78,7 +78,7 @@ force-single-line = true
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",
-  'ignore:distutils Version classes are deprecated:DeprecationWarning',
+  "ignore:distutils Version classes are deprecated:DeprecationWarning",
 ]
 xfail_strict = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,13 @@ ignore = [
   "ARG002",  # todo: enable
   "ARG003",  # todo: enable
   "C901",
+  "COM812",
   "D",
   "DTZ",
   "E501",
   "FBT003",  # todo: enable
   "FIX",
+  "ISC001",
   "PD",
   "PLR0911",
   "PLR0912",

--- a/tests/datetime_functions_test.py
+++ b/tests/datetime_functions_test.py
@@ -7,13 +7,11 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").dt.nanoseconds()\n',
-            'import polars as pl\n'
-            'pl.col("a").dt.total_nanoseconds()\n',
+            "import polars as pl\n" 'pl.col("a").dt.nanoseconds()\n',
+            "import polars as pl\n" 'pl.col("a").dt.total_nanoseconds()\n',
         ),
         # pytest.param(
         #     'import polars as pl\n'

--- a/tests/enable_string_cache_test.py
+++ b/tests/enable_string_cache_test.py
@@ -7,18 +7,16 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.enable_string_cache(True)\n',
+            "import polars as pl\n" "pl.enable_string_cache(True)\n",
             (0, 17, 0),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.enable_string_cache(1)\n',
+            "import polars as pl\n" "pl.enable_string_cache(1)\n",
             (0, 20, 0),
-            id='invalid',
+            id="invalid",
         ),
     ),
 )
@@ -27,19 +25,15 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.enable_string_cache(True)\n',
-            'import polars as pl\n'
-            'pl.enable_string_cache()\n',
+            "import polars as pl\n" "pl.enable_string_cache(True)\n",
+            "import polars as pl\n" "pl.enable_string_cache()\n",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.enable_string_cache(False)\n',
-            'import polars as pl\n'
-            'pl.disable_string_cache()\n',
+            "import polars as pl\n" "pl.enable_string_cache(False)\n",
+            "import polars as pl\n" "pl.disable_string_cache()\n",
         ),
     ),
 )

--- a/tests/group_by_arguments_test.py
+++ b/tests/group_by_arguments_test.py
@@ -7,10 +7,10 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'df.group_by_dynamic(truncate=1)\n',
+            "df.group_by_dynamic(truncate=1)\n",
             (0, 20, 0),
         ),
         pytest.param(
@@ -24,21 +24,19 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'df.group_by_dynamic(truncate=True)\n',
+            "df.group_by_dynamic(truncate=True)\n",
             'df.group_by_dynamic(label="left")\n',
         ),
         pytest.param(
-            'df.group_by_dynamic(truncate=False)\n',
+            "df.group_by_dynamic(truncate=False)\n",
             'df.group_by_dynamic(label="datapoint")\n',
         ),
         pytest.param(
-            'df.group_by_dynamic("ts", every="3d", '
-            'truncate=False, period="1d")\n',
-            'df.group_by_dynamic("ts", every="3d", '
-            'label="datapoint", period="1d")\n',
+            'df.group_by_dynamic("ts", every="3d", ' 'truncate=False, period="1d")\n',
+            'df.group_by_dynamic("ts", every="3d", ' 'label="datapoint", period="1d")\n',
         ),
     ),
 )

--- a/tests/group_by_dynamic_test.py
+++ b/tests/group_by_dynamic_test.py
@@ -7,12 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'df.groupby_dynamic',
+            "df.groupby_dynamic",
             (0, 17, 0),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -21,11 +21,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'df.groupby_dynamic',
-            'df.group_by_dynamic',
+            "df.groupby_dynamic",
+            "df.group_by_dynamic",
         ),
     ),
 )

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -23,7 +23,7 @@ def test_library_aliases() -> None:
 df.select(pl.count())
 """
     settings = Settings(target_version=(0, 20, 4))
-    result = rewrite(src, settings=settings, aliases={'pl'})
+    result = rewrite(src, settings=settings, aliases={"pl"})
     expected = """\
 df.select(pl.len())
 """
@@ -35,7 +35,7 @@ def test_library_aliases_polars() -> None:
 df.select(polars.count())
 """
     settings = Settings(target_version=(0, 20, 4))
-    result = rewrite(src, settings=settings, aliases={'polars'})
+    result = rewrite(src, settings=settings, aliases={"polars"})
     expected = """\
 df.select(polars.len())
 """

--- a/tests/map_dict_test.py
+++ b/tests/map_dict_test.py
@@ -7,31 +7,23 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").map_dict({2: 3})\n',
-            'import polars as pl\n'
-            'pl.col("a").replace({2: 3}, default=None)\n',
+            "import polars as pl\n" 'pl.col("a").map_dict({2: 3})\n',
+            "import polars as pl\n" 'pl.col("a").replace({2: 3}, default=None)\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").map_dict({2: 3},)\n',
-            'import polars as pl\n'
-            'pl.col("a").replace({2: 3},default=None)\n',
+            "import polars as pl\n" 'pl.col("a").map_dict({2: 3},)\n',
+            "import polars as pl\n" 'pl.col("a").replace({2: 3},default=None)\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").map_dict({2: 3}, default=3)\n',
-            'import polars as pl\n'
-            'pl.col("a").replace({2: 3}, default=3)\n',
+            "import polars as pl\n" 'pl.col("a").map_dict({2: 3}, default=3)\n',
+            "import polars as pl\n" 'pl.col("a").replace({2: 3}, default=3)\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").map_dict({2: 3}, foo=3 )\n',
-            'import polars as pl\n'
-            'pl.col("a").replace({2: 3}, foo=3, default=None )\n',
+            "import polars as pl\n" 'pl.col("a").map_dict({2: 3}, foo=3 )\n',
+            "import polars as pl\n" 'pl.col("a").replace({2: 3}, foo=3, default=None )\n',
         ),
     ),
 )

--- a/tests/map_groups_test.py
+++ b/tests/map_groups_test.py
@@ -7,7 +7,7 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
             'df.group_by("a").apply',

--- a/tests/pivot_kwonly_test.py
+++ b/tests/pivot_kwonly_test.py
@@ -7,23 +7,22 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'df.pivot(index=a, columns=b, values=c)\n',
+            "df.pivot(index=a, columns=b, values=c)\n",
             (0, 20, 10),
-            id='already kwonly',
+            id="already kwonly",
         ),
         pytest.param(
-            'df.pivot(a, columns=b, values=c)\n',
+            "df.pivot(a, columns=b, values=c)\n",
             (0, 20, 0),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import pandas as pd\n'
-            'df.pivot(a, columns=b, values=c)\n',
+            "import pandas as pd\n" "df.pivot(a, columns=b, values=c)\n",
             (0, 20, 10),
-            id='could be pandas',
+            id="could be pandas",
         ),
     ),
 )
@@ -32,46 +31,38 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(a, index=b, columns=c)\n',
-            'import polars as pl\n'
-            'df.pivot(values=a, index=b, columns=c)\n',
+            "import polars as pl\n" "df.pivot(a, index=b, columns=c)\n",
+            "import polars as pl\n" "df.pivot(values=a, index=b, columns=c)\n",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(a, b+c, c)\n',
-            'import polars as pl\n'
-            'df.pivot(values=a, b+c, c)\n',
+            "import polars as pl\n" "df.pivot(a, b+c, c)\n",
+            "import polars as pl\n" "df.pivot(values=a, b+c, c)\n",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot("a", b, "c")\n',
-            'import polars as pl\n'
-            'df.pivot(values="a", index=b, columns="c")\n',
+            "import polars as pl\n" 'df.pivot("a", b, "c")\n',
+            "import polars as pl\n" 'df.pivot(values="a", index=b, columns="c")\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(\'a\', b, "c")\n',
-            'import polars as pl\n'
-            'df.pivot(values="a", index=b, columns="c")\n',
+            "import polars as pl\n" "df.pivot('a', b, \"c\")\n",
+            "import polars as pl\n" 'df.pivot(values="a", index=b, columns="c")\n',
         ),
         pytest.param(
-            'import pandas as pd\n'
-            'import polars as pl\n'
+            "import pandas as pd\n"
+            "import polars as pl\n"
             'df.pivot("a", index=b, columns="c", aggregate_function="sum")\n',
-            'import pandas as pd\n'
-            'import polars as pl\n'
+            "import pandas as pd\n"
+            "import polars as pl\n"
             'df.pivot(values="a", index=b, columns="c", aggregate_function="sum")\n',
         ),
         pytest.param(
-            'import pandas as pd\n'
-            'import polars as pl\n'
+            "import pandas as pd\n"
+            "import polars as pl\n"
             'df.pivot("a", b, "c", "sum")\n',
-            'import pandas as pd\n'
-            'import polars as pl\n'
+            "import pandas as pd\n"
+            "import polars as pl\n"
             'df.pivot(values="a", index=b, columns="c", aggregate_function="sum")\n',
         ),
     ),

--- a/tests/renamed_dataframe_calls_test.py
+++ b/tests/renamed_dataframe_calls_test.py
@@ -7,19 +7,17 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.approx_n_unique()\n',
+            "import polars as pl\n" "df.approx_n_unique()\n",
             (0, 19, 19),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.approx_n_unique("foo")\n',
+            "import polars as pl\n" 'pl.approx_n_unique("foo")\n',
             (0, 20, 20),
-            id='has argument',
+            id="has argument",
         ),
     ),
 )
@@ -28,13 +26,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.approx_n_unique()\n',
-            'import polars as pl\n'
-            'df.select(pl.all().approx_n_unique())\n',
+            "import polars as pl\n" "df.approx_n_unique()\n",
+            "import polars as pl\n" "df.select(pl.all().approx_n_unique())\n",
         ),
     ),
 )

--- a/tests/renamed_dataframe_method_arguments_test.py
+++ b/tests/renamed_dataframe_method_arguments_test.py
@@ -7,19 +7,17 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.write_database(foo, if_exists="append")\n',
+            "import polars as pl\n" 'df.write_database(foo, if_exists="append")\n',
             (0, 19, 19),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.write_database(foo, if_table_exists="append")\n',
+            "import polars as pl\n" 'df.write_database(foo, if_table_exists="append")\n',
             (0, 20, 11),
-            id='already rewritten',
+            id="already rewritten",
         ),
     ),
 )
@@ -28,13 +26,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.write_database(foo, if_exists="append")\n',
-            'import polars as pl\n'
-            'df.write_database(foo, if_table_exists="append")\n',
+            "import polars as pl\n" 'df.write_database(foo, if_exists="append")\n',
+            "import polars as pl\n" 'df.write_database(foo, if_table_exists="append")\n',
         ),
     ),
 )

--- a/tests/renamed_dataframe_method_values_test.py
+++ b/tests/renamed_dataframe_method_values_test.py
@@ -7,25 +7,22 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(index=index, aggregate_function="count")\n',
+            "import polars as pl\n" 'df.pivot(index=index, aggregate_function="count")\n',
             (0, 19, 19),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(index=index, aggregate_function=count)\n',
+            "import polars as pl\n" "df.pivot(index=index, aggregate_function=count)\n",
             (0, 20, 5),
-            id='not constant',
+            id="not constant",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(index=index)\n',
+            "import polars as pl\n" "df.pivot(index=index)\n",
             (0, 20, 5),
-            id='no aggregate function',
+            id="no aggregate function",
         ),
     ),
 )
@@ -34,13 +31,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.pivot(index=index, aggregate_function="count")\n',
-            'import polars as pl\n'
-            'df.pivot(index=index, aggregate_function="len")\n',
+            "import polars as pl\n" 'df.pivot(index=index, aggregate_function="count")\n',
+            "import polars as pl\n" 'df.pivot(index=index, aggregate_function="len")\n',
         ),
     ),
 )

--- a/tests/renamed_expr_arguments_test.py
+++ b/tests/renamed_expr_arguments_test.py
@@ -7,21 +7,18 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").shift(3)\n',
+            "import polars as pl\n" 'pl.col("a").shift(3)\n',
             (0, 19, 19),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").shift(periods=3)\n',
+            "import polars as pl\n" 'pl.col("a").shift(periods=3)\n',
             (0, 19, 0),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").shift(n=3)\n',
+            "import polars as pl\n" 'pl.col("a").shift(n=3)\n',
             (0, 19, 19),
         ),
     ),
@@ -31,13 +28,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").shift(periods=4)\n',
-            'import polars as pl\n'
-            'pl.col("a").shift(n=4)\n',
+            "import polars as pl\n" 'pl.col("a").shift(periods=4)\n',
+            "import polars as pl\n" 'pl.col("a").shift(n=4)\n',
         ),
     ),
 )

--- a/tests/renamed_expr_functions_test.py
+++ b/tests/renamed_expr_functions_test.py
@@ -7,16 +7,14 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").cumsum()\n',
+            "import polars as pl\n" 'pl.col("a").cumsum()\n',
             (0, 19, 0),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").name.suffix("b")\n',
+            "import polars as pl\n" 'pl.col("a").name.suffix("b")\n',
             (0, 20, 0),
         ),
     ),
@@ -26,25 +24,19 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").cumsum()\n',
-            'import polars as pl\n'
-            'pl.col("a").cum_sum()\n',
+            "import polars as pl\n" 'pl.col("a").cumsum()\n',
+            "import polars as pl\n" 'pl.col("a").cum_sum()\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").mean().std().suffix("b")\n',
-            'import polars as pl\n'
-            'pl.col("a").mean().std().name.suffix("b")\n',
+            "import polars as pl\n" 'pl.col("a").mean().std().suffix("b")\n',
+            "import polars as pl\n" 'pl.col("a").mean().std().name.suffix("b")\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col.a.mean().std().suffix("b")\n',
-            'import polars as pl\n'
-            'pl.col.a.mean().std().name.suffix("b")\n',
+            "import polars as pl\n" 'pl.col.a.mean().std().suffix("b")\n',
+            "import polars as pl\n" 'pl.col.a.mean().std().name.suffix("b")\n',
         ),
     ),
 )

--- a/tests/renamed_list_arguments_test.py
+++ b/tests/renamed_list_arguments_test.py
@@ -7,21 +7,18 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.shift(3)\n',
+            "import polars as pl\n" 'pl.col("a").list.shift(3)\n',
             (0, 19, 19),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.shift(periods=3)\n',
+            "import polars as pl\n" 'pl.col("a").list.shift(periods=3)\n',
             (0, 19, 0),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.shift(n=3)\n',
+            "import polars as pl\n" 'pl.col("a").list.shift(n=3)\n',
             (0, 19, 19),
         ),
     ),
@@ -31,13 +28,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.shift(periods=4)\n',
-            'import polars as pl\n'
-            'pl.col("a").list.shift(n=4)\n',
+            "import polars as pl\n" 'pl.col("a").list.shift(periods=4)\n',
+            "import polars as pl\n" 'pl.col("a").list.shift(n=4)\n',
         ),
     ),
 )

--- a/tests/renamed_list_functions_test.py
+++ b/tests/renamed_list_functions_test.py
@@ -7,13 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.count_match()\n',
+            "import polars as pl\n" 'pl.col("a").list.count_match()\n',
             (0, 17, 0),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -22,13 +21,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").list.count_match()\n',
-            'import polars as pl\n'
-            'pl.col("a").list.count_matches()\n',
+            "import polars as pl\n" 'pl.col("a").list.count_match()\n',
+            "import polars as pl\n" 'pl.col("a").list.count_matches()\n',
         ),
     ),
 )

--- a/tests/renamed_meta_functions_test.py
+++ b/tests/renamed_meta_functions_test.py
@@ -7,13 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").meta.write_json\n',
+            "import polars as pl\n" 'pl.col("a").meta.write_json\n',
             (0, 20, 10),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -22,13 +21,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").meta.write_json(file)\n',
-            'import polars as pl\n'
-            'pl.col("a").meta.serialize(file)\n',
+            "import polars as pl\n" 'pl.col("a").meta.write_json(file)\n',
+            "import polars as pl\n" 'pl.col("a").meta.serialize(file)\n',
         ),
     ),
 )

--- a/tests/renamed_str_arguments_test.py
+++ b/tests/renamed_str_arguments_test.py
@@ -7,26 +7,22 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.parse_int(3)\n',
+            "import polars as pl\n" 'pl.col("a").str.parse_int(3)\n',
             (0, 19, 19),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.parse_int(radix=3)\n',
+            "import polars as pl\n" 'pl.col("a").str.parse_int(radix=3)\n',
             (0, 19, 0),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.parse_int(n=3)\n',
+            "import polars as pl\n" 'pl.col("a").str.parse_int(n=3)\n',
             (0, 19, 19),
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").parse_int(radix=3)\n',
+            "import polars as pl\n" 'pl.col("a").parse_int(radix=3)\n',
             (0, 19, 19),
         ),
     ),
@@ -36,13 +32,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.parse_int(radix=4)\n',
-            'import polars as pl\n'
-            'pl.col("a").str.parse_int(base=4)\n',
+            "import polars as pl\n" 'pl.col("a").str.parse_int(radix=4)\n',
+            "import polars as pl\n" 'pl.col("a").str.parse_int(base=4)\n',
         ),
     ),
 )

--- a/tests/renamed_toplevel_arguments_test.py
+++ b/tests/renamed_toplevel_arguments_test.py
@@ -7,13 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.scan_ndjson(foo, row_count_name="append")\n',
+            "import polars as pl\n" 'pl.scan_ndjson(foo, row_count_name="append")\n',
             (0, 19, 19),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -22,33 +21,29 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.scan_ndjson(foo, row_count_name="append")\n',
-            'import polars as pl\n'
-            'pl.scan_ndjson(foo, row_index_name="append")\n',
+            "import polars as pl\n" 'pl.scan_ndjson(foo, row_count_name="append")\n',
+            "import polars as pl\n" 'pl.scan_ndjson(foo, row_index_name="append")\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.scan_ndjson(foo, row_count_offset=3)\n',
-            'import polars as pl\n'
-            'pl.scan_ndjson(foo, row_index_offset=3)\n',
+            "import polars as pl\n" "pl.scan_ndjson(foo, row_count_offset=3)\n",
+            "import polars as pl\n" "pl.scan_ndjson(foo, row_index_offset=3)\n",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.scan_ndjson(\n'
-            '    foo,\n'
+            "import polars as pl\n"
+            "pl.scan_ndjson(\n"
+            "    foo,\n"
             '    row_count_name="foo",\n'
-            '    row_count_offset=3,\n'
-            ')\n',
-            'import polars as pl\n'
-            'pl.scan_ndjson(\n'
-            '    foo,\n'
+            "    row_count_offset=3,\n"
+            ")\n",
+            "import polars as pl\n"
+            "pl.scan_ndjson(\n"
+            "    foo,\n"
             '    row_index_name="foo",\n'
-            '    row_index_offset=3,\n'
-            ')\n',
+            "    row_index_offset=3,\n"
+            ")\n",
         ),
     ),
 )

--- a/tests/renamed_toplevel_functions_no_args_test.py
+++ b/tests/renamed_toplevel_functions_no_args_test.py
@@ -7,19 +7,17 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.count()\n',
+            "import polars as pl\n" "pl.count()\n",
             (0, 17, 0),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.count(a)\n',
+            "import polars as pl\n" "pl.count(a)\n",
             (0, 20, 5),
-            id='not deprecated',
+            id="not deprecated",
         ),
     ),
 )
@@ -28,14 +26,12 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.count()\n',
-            'import polars as pl\n'
-            'pl.len()\n',
-            id='yeah',
+            "import polars as pl\n" "pl.count()\n",
+            "import polars as pl\n" "pl.len()\n",
+            id="yeah",
         ),
     ),
 )

--- a/tests/saturating_test.py
+++ b/tests/saturating_test.py
@@ -7,19 +7,15 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("dt").dt.offset_by("1mo_saturating")\n',
-            'import polars as pl\n'
-            'pl.col("dt").dt.offset_by("1mo")\n',
+            "import polars as pl\n" 'pl.col("dt").dt.offset_by("1mo_saturating")\n',
+            "import polars as pl\n" 'pl.col("dt").dt.offset_by("1mo")\n',
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("dt").dt.offset_by(by="1mo_saturating")\n',
-            'import polars as pl\n'
-            'pl.col("dt").dt.offset_by(by="1mo")\n',
+            "import polars as pl\n" 'pl.col("dt").dt.offset_by(by="1mo_saturating")\n',
+            "import polars as pl\n" 'pl.col("dt").dt.offset_by(by="1mo")\n',
         ),
     ),
 )

--- a/tests/string_functions_test.py
+++ b/tests/string_functions_test.py
@@ -7,13 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.json_extract()\n',
+            "import polars as pl\n" 'pl.col("a").str.json_extract()\n',
             (0, 17, 0),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -22,13 +21,11 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.col("a").str.json_extract()\n',
-            'import polars as pl\n'
-            'pl.col("a").str.json_decode()\n',
+            "import polars as pl\n" 'pl.col("a").str.json_extract()\n',
+            "import polars as pl\n" 'pl.col("a").str.json_decode()\n',
         ),
     ),
 )

--- a/tests/toplevel_functions_test.py
+++ b/tests/toplevel_functions_test.py
@@ -7,19 +7,17 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.avg\n',
+            "import polars as pl\n" "pl.avg\n",
             (0, 17, 0),
-            id='too old',
+            id="too old",
         ),
         pytest.param(
-            'import polars as pl\n'
-            'pl.col\n',
+            "import polars as pl\n" "pl.col\n",
             (0, 20, 0),
-            id='not deprecated',
+            id="not deprecated",
         ),
     ),
 )
@@ -28,14 +26,12 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'pl.avg\n',
-            'import polars as pl\n'
-            'pl.mean\n',
-            id='top-level functions',
+            "import polars as pl\n" "pl.avg\n",
+            "import polars as pl\n" "pl.mean\n",
+            id="top-level functions",
         ),
     ),
 )

--- a/tests/validate_readme.py
+++ b/tests/validate_readme.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import re
 
-with open('README.md') as f:
+with open("README.md") as f:
     lines = f.readlines()
 
 
 def find_line(lines, match):
-    for (i, l) in enumerate(lines):
+    for i, l in enumerate(lines):
         if match in l:
             return i
     return None
 
 
-versions = re.findall(r'Version (\d+\.\d+\.\d+)', ''.join(lines))
+versions = re.findall(r"Version (\d+\.\d+\.\d+)", "".join(lines))
 print(versions)
 
-content = ''.join([line[2:] for line in lines if line.startswith('- ')])
-with open('tmp.py', 'w') as f:
-    f.write('import polars as pl\n' + content)
+content = "".join([line[2:] for line in lines if line.startswith("- ")])
+with open("tmp.py", "w") as f:
+    f.write("import polars as pl\n" + content)

--- a/tests/with_row_count_test.py
+++ b/tests/with_row_count_test.py
@@ -7,13 +7,12 @@ from polars_upgrade._main import fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s', 'version'),
+    ("s", "version"),
     (
         pytest.param(
-            'import polars as pl\n'
-            'df.with_row_count()\n',
+            "import polars as pl\n" "df.with_row_count()\n",
             (0, 19, 19),
-            id='too old',
+            id="too old",
         ),
     ),
 )
@@ -22,10 +21,10 @@ def test_fix_capture_output_noop(s, version):
 
 
 @pytest.mark.parametrize(
-    ('s', 'expected'),
+    ("s", "expected"),
     (
         pytest.param(
-            'df.with_row_count()\n',
+            "df.with_row_count()\n",
             'df.with_row_index("row_nr", )\n',
         ),
         pytest.param(


### PR DESCRIPTION
Had to ignore two more rules ([ISC001](https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/) and [COM812](https://docs.astral.sh/ruff/rules/missing-trailing-comma/) because the ruff formatter complained about it:

```
warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
```

Also hey I reduced the total LoCs.