### PR TITLE
build: Support py38

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   tox:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: (bump_version\.py|tmp\.py|validate_readme\.py)
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,26 +17,26 @@ repos:
     rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py39-plus, --add-import, 'from __future__ import annotations']
+        args: [--py38-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.2
     hooks:
     -   id: pyupgrade
-        args: [--py39-plus]
+        args: [--py38-plus, --keep-runtime-typing]
 -   repo: https://github.com/hhatto/autopep8
-    rev: v2.0.4
+    rev: v2.1.0
     hooks:
     -   id: autopep8
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
         args: [--max-line-length=100]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.10.0
     hooks:
     -   id: mypy

--- a/polars_upgrade/_ast_helpers.py
+++ b/polars_upgrade/_ast_helpers.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import ast
 import warnings
-from collections.abc import Container
+from typing import TYPE_CHECKING
 
 from tokenize_rt import Offset
+
+if TYPE_CHECKING:
+    from typing import Container
+    from typing import Dict
+    from typing import Set
+    from typing import Tuple
 
 
 def ast_parse(contents_text: str) -> ast.Module:
@@ -20,19 +26,19 @@ def ast_to_offset(node: ast.expr | ast.stmt) -> Offset:
 
 def is_name_attr(
     node: ast.AST,
-    imports: dict[str, set[str]],
-    mods: tuple[str, ...],
+    imports: Dict[str, Set[str]],
+    mods: Tuple[str, ...],
     names: Container[str],
 ) -> bool:
     return (
-        isinstance(node, ast.Name)
-        and node.id in names
-        and any(node.id in imports[mod] for mod in mods)
+        isinstance(node, ast.Name) and
+        node.id in names and
+        any(node.id in imports[mod] for mod in mods)
     ) or (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id in mods
-        and node.attr in names
+        isinstance(node, ast.Attribute) and
+        isinstance(node.value, ast.Name) and
+        node.value.id in mods and
+        node.attr in names
     )
 
 
@@ -55,9 +61,9 @@ def is_async_listcomp(node: ast.ListComp) -> bool:
 
 def is_type_check(node: ast.AST) -> bool:
     return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id in {"isinstance", "issubclass"}
-        and len(node.args) == 2
-        and not has_starargs(node)
+        isinstance(node, ast.Call) and
+        isinstance(node.func, ast.Name) and
+        node.func.id in {"isinstance", "issubclass"} and
+        len(node.args) == 2 and
+        not has_starargs(node)
     )

--- a/polars_upgrade/_data.py
+++ b/polars_upgrade/_data.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import ast
 import collections
 import pkgutil
-from collections.abc import Iterable
 from typing import Callable
+from typing import Dict
+from typing import Iterable
+from typing import List
 from typing import NamedTuple
 from typing import Protocol
+from typing import Tuple
 from typing import TypeVar
 
 from tokenize_rt import Offset
@@ -14,7 +17,7 @@ from tokenize_rt import Token
 
 from polars_upgrade import _plugins
 
-Version = tuple[int, ...]
+Version = Tuple[int, ...]
 
 
 class Settings(NamedTuple):
@@ -23,13 +26,13 @@ class Settings(NamedTuple):
 
 class State(NamedTuple):
     settings: Settings
-    aliases: dict[str, set[str]]
+    aliases: Dict[str, set[str]]
     in_annotation: bool = False
 
 
 AST_T = TypeVar("AST_T", bound=ast.AST)
-TokenFunc = Callable[[int, list[Token]], None]
-ASTFunc = Callable[[State, AST_T, ast.AST], Iterable[tuple[Offset, TokenFunc]]]
+TokenFunc = Callable[[int, List[Token]], None]
+ASTFunc = Callable[[State, AST_T, ast.AST], Iterable[Tuple[Offset, TokenFunc]]]
 
 RECORD_FROM_IMPORTS = frozenset(("polars",))
 
@@ -45,7 +48,7 @@ def register(tp: type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
 
 
 class ASTCallbackMapping(Protocol):
-    def __getitem__(self, tp: type[AST_T]) -> list[ASTFunc[AST_T]]: ...
+    def __getitem__(self, tp: type[AST_T]) -> List[ASTFunc[AST_T]]: ...
 
 
 def visit(
@@ -53,7 +56,7 @@ def visit(
     tree: ast.Module,
     settings: Settings,
     aliases: set[str] | None = None,
-) -> dict[Offset, list[TokenFunc]]:
+) -> Dict[Offset, List[TokenFunc]]:
     if aliases is not None:
         _aliases = collections.defaultdict(set)
         _aliases["polars"].update(aliases)
@@ -68,7 +71,7 @@ def visit(
             aliases=_aliases,
         )
 
-    nodes: list[tuple[State, ast.AST, ast.AST]] = [(initial_state, tree, tree)]
+    nodes: List[Tuple[State, ast.AST, ast.AST]] = [(initial_state, tree, tree)]
 
     ret = collections.defaultdict(list)
     while nodes:

--- a/polars_upgrade/_plugins/group_by_dynamic_truncate.py
+++ b/polars_upgrade/_plugins/group_by_dynamic_truncate.py
@@ -2,23 +2,28 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import find_op
 from polars_upgrade._token_helpers import parse_call_args
 from polars_upgrade._token_helpers import replace_argument
 
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
+
 
 def _use_label(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     truncate_value: object,
     truncate_idx: int,
@@ -44,18 +49,18 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr == "group_by_dynamic"
-        and len(node.keywords) >= 1
-        and state.settings.target_version >= (0, 19, 4)
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr == "group_by_dynamic" and
+        len(node.keywords) >= 1 and
+        state.settings.target_version >= (0, 19, 4)
     ):
         truncate_idx = None
         truncate_value = None
         for n, keyword_argument in enumerate(node.keywords):
             if keyword_argument.arg == "truncate" and isinstance(
-                keyword_argument.value, ast.Constant
+                keyword_argument.value, ast.Constant,
             ):
                 truncate_idx = n
                 truncate_value = keyword_argument.value.value

--- a/polars_upgrade/_plugins/map_dict.py
+++ b/polars_upgrade/_plugins/map_dict.py
@@ -4,23 +4,29 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from tokenize_rt import NON_CODING_TOKENS
-from tokenize_rt import Offset
 from tokenize_rt import Token
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import find_op
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -32,7 +38,7 @@ def rename(
 
 def rename_and_add_default(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -62,12 +68,12 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and is_simple_expression(node.func.value, state.aliases["polars"])
-        and node.func.attr == "map_dict"
-        and state.settings.target_version >= (0, 19, 16)
+        isinstance(node.func, ast.Attribute) and
+        is_simple_expression(node.func.value, state.aliases["polars"]) and
+        node.func.attr == "map_dict" and
+        state.settings.target_version >= (0, 19, 16)
     ):
         if any(k.arg == "default" for k in node.keywords):
             func = functools.partial(

--- a/polars_upgrade/_plugins/map_groups.py
+++ b/polars_upgrade/_plugins/map_groups.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -30,18 +35,18 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        node.attr == "apply"
-        and isinstance(node.value, ast.Call)
-        and isinstance(node.value.func, ast.Attribute)
-        and node.value.func.attr
+        node.attr == "apply" and
+        isinstance(node.value, ast.Call) and
+        isinstance(node.value.func, ast.Attribute) and
+        node.value.func.attr
         in (
             "group_by",
             "group_by_dynamic",
             "rolling",
-        )
-        and state.settings.target_version >= (0, 19, 0)
+        ) and
+        state.settings.target_version >= (0, 19, 0)
     ):
         func = functools.partial(rename, name=node.attr, new="map_groups")
         yield ast_to_offset(node), func

--- a/polars_upgrade/_plugins/pivot_kwonly.py
+++ b/polars_upgrade/_plugins/pivot_kwonly.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -41,12 +46,11 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr == "pivot"
-        and node.args
-        and
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr == "pivot" and
+        node.args and
         # check that it's probably not pandas, either because of unique keywords
         # or because pandas was never imported in this file
         (
@@ -58,11 +62,11 @@ def visit_Call(
                     "sort_columns",
                     "maintain_order",
                 ]
-            )
-            or len(node.args) > 3
-            or ("pandas" not in state.aliases)
-        )
-        and state.settings.target_version >= (0, 20, 8)
+            ) or
+            len(node.args) > 3 or
+            ("pandas" not in state.aliases)
+        ) and
+        state.settings.target_version >= (0, 20, 8)
     ):
         for i, arg in enumerate(node.args):
             if isinstance(arg, ast.Name):

--- a/polars_upgrade/_plugins/renamed_dataframe_calls.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_calls.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -41,13 +46,13 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr in RENAMINGS
-        and "pl" in state.aliases["polars"]
-        and not node.args
-        and not node.keywords
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr in RENAMINGS and
+        "pl" in state.aliases["polars"] and
+        not node.args and
+        not node.keywords
     ):
         min_version, new_name = RENAMINGS[node.func.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_dataframe_method_arguments.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_method_arguments.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -44,11 +49,11 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr in RENAMINGS
-        and len(node.keywords) >= 1
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr in RENAMINGS and
+        len(node.keywords) >= 1
     ):
         min_version, old, new = RENAMINGS[node.func.attr]
         if not state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_dataframe_method_values.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_method_values.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -44,7 +49,7 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if isinstance(node.func, ast.Attribute) and node.func.attr in RENAMINGS:
         min_version, argument, old, new = RENAMINGS[node.func.attr]
         if argument not in {kw.arg for kw in node.keywords}:

--- a/polars_upgrade/_plugins/renamed_dataframe_methods.py
+++ b/polars_upgrade/_plugins/renamed_dataframe_methods.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -36,7 +41,7 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if node.attr in RENAMINGS:
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_datetime_functions.py
+++ b/polars_upgrade/_plugins/renamed_datetime_functions.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new_name: str,
@@ -31,13 +36,13 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        state.settings.target_version >= (0, 19, 13)
-        and isinstance(node.value, ast.Attribute)
-        and is_simple_expression(node.value.value, state.aliases["polars"])
-        and node.value.attr == "dt"
-        and node.attr
+        state.settings.target_version >= (0, 19, 13) and
+        isinstance(node.value, ast.Attribute) and
+        is_simple_expression(node.value.value, state.aliases["polars"]) and
+        node.value.attr == "dt" and
+        node.attr
         in (
             "nanoseconds",
             "microseconds",

--- a/polars_upgrade/_plugins/renamed_expr_arguments.py
+++ b/polars_upgrade/_plugins/renamed_expr_arguments.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -50,15 +55,15 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        is_simple_expression(node.value, state.aliases["polars"])
-        and isinstance(parent, ast.Call)
-        and isinstance(parent.func, ast.Attribute)
-        and parent.func.attr in RENAMINGS
-        and not (
-            isinstance(node.value, ast.Attribute)
-            and node.value.attr in ("list", "name", "str", "struct", "dt")
+        is_simple_expression(node.value, state.aliases["polars"]) and
+        isinstance(parent, ast.Call) and
+        isinstance(parent.func, ast.Attribute) and
+        parent.func.attr in RENAMINGS and
+        not (
+            isinstance(node.value, ast.Attribute) and
+            node.value.attr in ("list", "name", "str", "struct", "dt")
         )
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]

--- a/polars_upgrade/_plugins/renamed_expr_functions.py
+++ b/polars_upgrade/_plugins/renamed_expr_functions.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -53,13 +58,13 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        is_simple_expression(node.value, state.aliases["polars"])
-        and node.attr in RENAMINGS
-        and not (
-            isinstance(node.value, ast.Attribute)
-            and node.value.attr in ("list", "name", "str", "struct", "dt")
+        is_simple_expression(node.value, state.aliases["polars"]) and
+        node.attr in RENAMINGS and
+        not (
+            isinstance(node.value, ast.Attribute) and
+            node.value.attr in ("list", "name", "str", "struct", "dt")
         )
     ):
         min_version, new_name = RENAMINGS[node.attr]

--- a/polars_upgrade/_plugins/renamed_list_arguments.py
+++ b/polars_upgrade/_plugins/renamed_list_arguments.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -46,13 +51,13 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        is_simple_expression(node.value, state.aliases["polars"])
-        and isinstance(parent, ast.Call)
-        and isinstance(parent.func, ast.Attribute)
-        and parent.func.attr in RENAMINGS
-        and (isinstance(node.value, ast.Attribute) and node.value.attr == "list")
+        is_simple_expression(node.value, state.aliases["polars"]) and
+        isinstance(parent, ast.Call) and
+        isinstance(parent.func, ast.Attribute) and
+        parent.func.attr in RENAMINGS and
+        (isinstance(node.value, ast.Attribute) and node.value.attr == "list")
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]
         for keyword in parent.keywords:

--- a/polars_upgrade/_plugins/renamed_list_functions.py
+++ b/polars_upgrade/_plugins/renamed_list_functions.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -38,12 +43,12 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.value, ast.Attribute)
-        and is_simple_expression(node.value.value, state.aliases["polars"])
-        and node.value.attr == "list"
-        and node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute) and
+        is_simple_expression(node.value.value, state.aliases["polars"]) and
+        node.value.attr == "list" and
+        node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_meta_functions.py
+++ b/polars_upgrade/_plugins/renamed_meta_functions.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -36,12 +41,12 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.value, ast.Attribute)
-        and is_simple_expression(node.value.value, state.aliases["polars"])
-        and node.value.attr == "meta"
-        and node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute) and
+        is_simple_expression(node.value.value, state.aliases["polars"]) and
+        node.value.attr == "meta" and
+        node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_str_arguments.py
+++ b/polars_upgrade/_plugins/renamed_str_arguments.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -48,13 +53,13 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        is_simple_expression(node.value, state.aliases["polars"])
-        and isinstance(parent, ast.Call)
-        and isinstance(parent.func, ast.Attribute)
-        and parent.func.attr in RENAMINGS
-        and (isinstance(node.value, ast.Attribute) and node.value.attr == "str")
+        is_simple_expression(node.value, state.aliases["polars"]) and
+        isinstance(parent, ast.Call) and
+        isinstance(parent.func, ast.Attribute) and
+        parent.func.attr in RENAMINGS and
+        (isinstance(node.value, ast.Attribute) and node.value.attr == "str")
     ):
         min_version, old, new = RENAMINGS[parent.func.attr]
         for keyword in parent.keywords:

--- a/polars_upgrade/_plugins/renamed_string_functions.py
+++ b/polars_upgrade/_plugins/renamed_string_functions.py
@@ -2,21 +2,26 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import is_simple_expression
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     name: str,
     new: str,
@@ -44,12 +49,12 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.value, ast.Attribute)
-        and is_simple_expression(node.value.value, state.aliases["polars"])
-        and node.value.attr == "str"
-        and node.attr in RENAMINGS
+        isinstance(node.value, ast.Attribute) and
+        is_simple_expression(node.value.value, state.aliases["polars"]) and
+        node.value.attr == "str" and
+        node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_toplevel_arguments.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_arguments.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def rename(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
     *,
     line: int,
     utf8_byte_offset: int,
@@ -86,13 +91,13 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr in RENAMINGS
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id in state.aliases["polars"]
-        and len(node.keywords) >= 1
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr in RENAMINGS and
+        isinstance(node.func.value, ast.Name) and
+        node.func.value.id in state.aliases["polars"] and
+        len(node.keywords) >= 1
     ):
         for min_version, old, new in RENAMINGS[node.func.attr]:
             if not state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_toplevel_functions.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_functions.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import replace_name
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import Tuple
+
+    from tokenize_rt import Offset
 
 RENAMINGS = {
     "avg": ((0, 18, 12), "mean"),
@@ -29,11 +33,11 @@ def visit_Attribute(
     state: State,
     node: ast.Attribute,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.value, ast.Name)
-        and node.value.id in state.aliases["polars"]
-        and node.attr in RENAMINGS
+        isinstance(node.value, ast.Name) and
+        node.value.id in state.aliases["polars"] and
+        node.attr in RENAMINGS
     ):
         min_version, new_name = RENAMINGS[node.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/renamed_toplevel_no_arg_functions.py
+++ b/polars_upgrade/_plugins/renamed_toplevel_no_arg_functions.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
 from polars_upgrade._token_helpers import replace_name
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import Tuple
+
+    from tokenize_rt import Offset
 
 RENAMINGS = {
     "count": ((0, 20, 4), "len"),
@@ -22,14 +26,14 @@ def visit_Call(
     state: State,
     node: ast.Call,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id in state.aliases["polars"]
-        and node.func.attr in RENAMINGS
-        and not node.args
-        and not node.keywords
+        isinstance(node.func, ast.Attribute) and
+        isinstance(node.func.value, ast.Name) and
+        node.func.value.id in state.aliases["polars"] and
+        node.func.attr in RENAMINGS and
+        not node.args and
+        not node.keywords
     ):
         min_version, new_name = RENAMINGS[node.func.attr]
         if state.settings.target_version >= min_version:

--- a/polars_upgrade/_plugins/saturating.py
+++ b/polars_upgrade/_plugins/saturating.py
@@ -2,20 +2,25 @@ from __future__ import annotations
 
 import ast
 import functools
-from collections.abc import Iterable
-
-from tokenize_rt import Offset
-from tokenize_rt import Token
+from typing import TYPE_CHECKING
 
 from polars_upgrade._ast_helpers import ast_to_offset
+from polars_upgrade._data import register
 from polars_upgrade._data import State
 from polars_upgrade._data import TokenFunc
-from polars_upgrade._data import register
+
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import List
+    from typing import Tuple
+
+    from tokenize_rt import Offset
+    from tokenize_rt import Token
 
 
 def myfunc(
     i: int,
-    tokens: list[Token],
+    tokens: List[Token],
 ) -> None:
     tokens[i] = tokens[i]._replace(src=tokens[i].src.replace("mo_saturating", "mo"))
 
@@ -25,12 +30,12 @@ def visit_Constant(
     state: State,
     node: ast.Constant,
     parent: ast.AST,
-) -> Iterable[tuple[Offset, TokenFunc]]:
+) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.value, str)
-        and node.value.endswith("mo_saturating")
-        and isinstance(parent, (ast.Call, ast.keyword))
-        and state.settings.target_version >= (0, 19, 3)
+        isinstance(node.value, str) and
+        node.value.endswith("mo_saturating") and
+        isinstance(parent, (ast.Call, ast.keyword)) and
+        state.settings.target_version >= (0, 19, 3)
     ):
         func = functools.partial(myfunc)
         yield ast_to_offset(node), func

--- a/polars_upgrade/_string_helpers.py
+++ b/polars_upgrade/_string_helpers.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 import codecs
 import re
 import string
+from typing import List
 from typing import Optional
+from typing import Tuple
 
 NAMED_UNICODE_RE = re.compile(r"(?<!\\)(?:\\\\)*(\\N\{[^}]+\})")
 
-DotFormatPart = tuple[str, Optional[str], Optional[str], Optional[str]]
+DotFormatPart = Tuple[str, Optional[str], Optional[str], Optional[str]]
 
 _stdlib_parse_format = string.Formatter().parse
 
 
-def parse_format(s: str) -> list[DotFormatPart]:
+def parse_format(s: str) -> List[DotFormatPart]:
     """handle named escape sequences"""
-    ret: list[DotFormatPart] = []
+    ret: List[DotFormatPart] = []
 
     for part in NAMED_UNICODE_RE.split(s):
         if NAMED_UNICODE_RE.fullmatch(part):
@@ -37,7 +39,7 @@ def parse_format(s: str) -> list[DotFormatPart]:
     return ret
 
 
-def unparse_parsed_string(parsed: list[DotFormatPart]) -> str:
+def unparse_parsed_string(parsed: List[DotFormatPart]) -> str:
     def _convert_tup(tup: DotFormatPart) -> str:
         ret, field_name, format_spec, conversion = tup
         ret = curly_escape(ret)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Automatically upgrade Polars code to the latest version."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ ignore = [
 [tool.ruff.lint.isort]
 force-single-line = true
 
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
+
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
 [project.scripts]
 polars-upgrade = "polars_upgrade._main:main"
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.1.1",
+]
+
 [tool.ruff]
 line-length = 90
 fix = true


### PR DESCRIPTION
Ciao Marco, after ten thousand years here is the PR. I had to:

1. Update a couple of hooks in `.pre-commit-config.yaml` to use `py38`.
2. Replace all `collections.abc` with`typing` as they are not subscriptable in py38.
3. Import `Tuple`, `List` , `Dict` and `Set` over the regular counterparts.
4. Took the change and hid some imports behing `TYPE_CHECKING` so that my effort is not completely nullified in a bunch of months when Python stops supporting Py38 (lol).
5. Added py38 to GH Actions matrix.

There are some 8 tests that fail, but that seems because the `keyword` object does not have a `lineno` attribute. Did I mess something up?

I also noticed a `toxfile` but never ran the test with that, should I do that too? And how?

If approved, closes #11.